### PR TITLE
Add tabs to simplify character sheet

### DIFF
--- a/src/lib/components/Features.svelte
+++ b/src/lib/components/Features.svelte
@@ -1,70 +1,51 @@
 <script lang="ts">
-	import {
-		ExpandableTile,
-		ListItem,
-		Tag,
-		Tile,
-		UnorderedList
-	} from 'carbon-components-svelte';
+	import { ExpandableTile, ListItem, Tag, UnorderedList } from 'carbon-components-svelte';
 
 	export let character;
 	$: feature_sources = character.feature_sources;
 </script>
 
-<div>
-	<br /><br />
-	<Tile>
-		<h1>Features</h1>
-	</Tile>
-
-	{#each feature_sources as feature_source}
-		<ExpandableTile tileExpandedLabel="View less" tileCollapsedLabel="View more">
-			<div slot="above">
-				<h3>
-					{feature_source.title}
-					<Tag type="cyan">{feature_source.type.toUpperCase()}</Tag>
-				</h3>
-			</div>
-			<div slot="below">
-				<br />
-				{#each feature_source.features as feature}
-					<ExpandableTile
-						tileExpandedLabel="View less"
-						tileCollapsedLabel="View more"
-						on:click={(e) => {
-							e.stopPropagation();
-						}}
-					>
-						<div slot="above">
-							<h4>
-								{feature.title}
-								{#if feature.accessedLevel <= character.level}
-									<Tag type="cool-gray">Lvl. {feature.accessedLevel}</Tag>
-								{:else}
-									<Tag type="outline" disabled>
-										Lvl. {feature.accessedLevel}
-									</Tag>
-								{/if}
-							</h4>
-						</div>
-						<div slot="below">
-							<br />
-							<UnorderedList expressive>
-								{#each feature.description as line}
-									<ListItem>{line}</ListItem>
-								{/each}
-							</UnorderedList>
-							<br /> <br />
-						</div>
-					</ExpandableTile>
-				{/each}
-			</div>
-		</ExpandableTile>
-	{/each}
-</div>
-
-<style>
-	h1 {
-		text-align: center;
-	}
-</style>
+{#each feature_sources as feature_source}
+	<ExpandableTile tileExpandedLabel="View less" tileCollapsedLabel="View more">
+		<div slot="above">
+			<h3>
+				{feature_source.title}
+				<Tag type="cyan">{feature_source.type.toUpperCase()}</Tag>
+			</h3>
+		</div>
+		<div slot="below">
+			<br />
+			{#each feature_source.features as feature}
+				<ExpandableTile
+					tileExpandedLabel="View less"
+					tileCollapsedLabel="View more"
+					on:click={(e) => {
+						e.stopPropagation();
+					}}
+				>
+					<div slot="above">
+						<h4>
+							{feature.title}
+							{#if feature.accessedLevel <= character.level}
+								<Tag type="cool-gray">Lvl. {feature.accessedLevel}</Tag>
+							{:else}
+								<Tag type="outline" disabled>
+									Lvl. {feature.accessedLevel}
+								</Tag>
+							{/if}
+						</h4>
+					</div>
+					<div slot="below">
+						<br />
+						<UnorderedList expressive>
+							{#each feature.description as line}
+								<ListItem>{line}</ListItem>
+							{/each}
+						</UnorderedList>
+						<br /> <br />
+					</div>
+				</ExpandableTile>
+			{/each}
+		</div>
+	</ExpandableTile>
+{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Tag, Tile, FileUploader, Link } from 'carbon-components-svelte';
+	import { Tag, Tile, FileUploader, Link, Tabs, Tab, TabContent } from 'carbon-components-svelte';
 
 	import { userIsAuthenticated, config as configStore } from '$lib/stores';
 
@@ -115,15 +115,21 @@
 </div>
 <AbilityScores {character} />
 <Health {character}></Health>
-<div>
-	<Tile>
-		<h1>Weapons</h1>
-	</Tile>
-	{#each character.weapons as weapon}
-		<Weapon {weapon} {character} />
-	{/each}
-</div>
-<Features {character} />
+
+<Tabs>
+	<Tab label="1. Weapons" />
+	<Tab label="2. Features" />
+	<svelte:fragment slot="content">
+		<TabContent>
+			{#each character.weapons as weapon}
+				<Weapon {weapon} {character} />
+			{/each}
+		</TabContent>
+		<TabContent>
+			<Features {character} />
+		</TabContent>
+	</svelte:fragment>
+</Tabs>
 
 <style>
 	h1,


### PR DESCRIPTION
Weapons and Features sections moved to their tab. This way, you can switch in between them at ease. 